### PR TITLE
some improvements to build.gradle.kts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,23 +31,20 @@ jobs:
           git config --global user.name "Github Actions"
       - name: Patch
         run: |
-          ./gradlew applyPatches --stacktrace --no-daemon
-      - name: Get MC Version
-        run: echo "::set-output name=mcver::$(grep mcVersion gradle.properties | awk '{print $3;}')"
-        id: mcver
+          ./gradlew applyPatches --stacktrace
       - name: Build
         run: |
-          ./gradlew build --stacktrace --no-daemon
-          ./gradlew paperclipJar --stacktrace --no-daemon
+          ./gradlew build --stacktrace
+          ./gradlew paperclipJar --stacktrace
       - name: Archive Paperclip
         uses: actions/upload-artifact@v2
         with:
           name: Patina
-          path: build/libs/Patina-${{ steps.mcver.outputs.mcver }}-R0.1-SNAPSHOT.jar
+          path: patina-paperclip.jar
       - name: Prepare Github Page Files
         run: |
           mkdir -p public
-          cp build/libs/Patina-${{ steps.mcver.outputs.mcver }}-R0.1-SNAPSHOT.jar public/
+          cp patina-paperclip.jar public/
       - name: Deploy to Github Pages
         if: github.event_name != 'pull_request'
         uses: peaceiris/actions-gh-pages@v3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     java
     id("com.github.johnrengelman.shadow") version "7.0.0" apply false
-    id("io.papermc.paperweight.patcher") version "1.1.8"
+    id("io.papermc.paperweight.patcher") version "1.1.9-SNAPSHOT"
 }
 
 repositories {
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
     remapper("org.quiltmc:tiny-remapper:0.4.1")
-    paperclip("io.papermc:paperclip:2.0.0-SNAPSHOT@jar")
+    paperclip("io.papermc:paperclip:2.0.1@jar")
 }
 
 subprojects {
@@ -33,8 +33,17 @@ subprojects {
     }
 
     tasks.withType<JavaCompile>().configureEach {
-        options.encoding = "UTF-8"
+        options.isIncremental = true
+        options.encoding = Charsets.UTF_8.name()
         options.release.set(16)
+    }
+
+    tasks.withType<Javadoc>().configureEach {
+        options.encoding = Charsets.UTF_8.name()
+    }
+
+    tasks.withType<ProcessResources>().configureEach {
+        filteringCharset = Charsets.UTF_8.name()
     }
 
     repositories {
@@ -70,4 +79,8 @@ paperweight {
             }
         }
     }
+}
+tasks.paperclipJar {
+    destinationDirectory.set(rootProject.layout.projectDirectory)
+    archiveFileName.set("patina-paperclip.jar")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     java
     id("com.github.johnrengelman.shadow") version "7.0.0" apply false
-    id("io.papermc.paperweight.patcher") version "1.1.9-SNAPSHOT"
+    id("io.papermc.paperweight.patcher") version "1.1.8"
 }
 
 repositories {


### PR DESCRIPTION
Updated:

+ Paperweight to 1.1.9-SNAPSHOT
+ Paperclip to 2.0.1

Changed:

+ Paperclip jar is now placed in the root dir and changed it’s name to `patina-paperclip.jar`
+ Use UTF-8 for JavaCompile , Javadoc , ProcessResources
+ JavaCompile is now incremental